### PR TITLE
Added jQuery mobile and swipe

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 		<script src="http://fargo.io/code/node/shared/alertdialog.js"></script>
 		<script src="http://fargo.io/code/shared/beep.js"></script>
 		<script src="http://fargo.io/code/shared/emojify.js"></script>
+		<script src="http://code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.js"></script>
 		
 		<script>
 			var appConsts = {
@@ -175,6 +176,13 @@
 								break;
 							}
 						});
+					//Add swipe to change clues - depends on jQuery mobile
+					$("#idTextContainer").on("swipeleft",function(){
+					  nextClue ();
+					});
+					$("#idTextContainer").on("swiperight",function(){
+					  prevClue ();
+					});
 					self.setInterval (function () {everySecond ()}, 1000); 
 					});
 				}


### PR DESCRIPTION
Thought it would be useful to add swipe gestures so that users on touch devices could swipe to advance to next clue or go back to previous clue.

I included jQuery Mobile javascript from code.jquery.com (this could be changed if you prefer to host javascript files yourself.)

Added jQuery on() handlers to the idTextContainer div to catch swipeleft and swiperight events. Swiperight calls prevClue() and swipeleft calls nextClue().
